### PR TITLE
Históricos salvando com ativo null

### DIFF
--- a/src/main/java/br/com/ottimizza/integradorcloud/domain/models/Historico.java
+++ b/src/main/java/br/com/ottimizza/integradorcloud/domain/models/Historico.java
@@ -75,6 +75,7 @@ public class Historico implements Serializable {
     @PreUpdate
     public void preUpdate() {
         if (dataCriacao == null) {
+            this.ativo = true;
             this.dataCriacao = new Date();
         }
         this.dataAtualizacao = new Date();


### PR DESCRIPTION
### Qual era o problema?

> Não setavamos ativo true quando criava um histórico.

### Como ele foi resolvido? 

> Adicionando ativo true no prePersist do histórico.

### Qual o resultado esperado? 

> Os históricos criados agora possuam ativo true.
