### PR TITLE
TotalElements errado na tela de projetos

### DIFF
--- a/src/main/java/br/com/ottimizza/integradorcloud/repositories/roteiro/RoteiroRepositoryImpl.java
+++ b/src/main/java/br/com/ottimizza/integradorcloud/repositories/roteiro/RoteiroRepositoryImpl.java
@@ -59,11 +59,12 @@ public class RoteiroRepositoryImpl implements RoteiroRepositoryCustom{
 		
 		if(filtro.getId() != null)
 			query.setParameter("roteiroId", filtro.getId());
-		
+
+		long totalElements = query.getResultList().size();
 		query.setFirstResult(criteria.getPageIndex() * criteria.getPageSize());
 		query.setMaxResults(criteria.getPageSize());
 			
-		return new PageImpl<Roteiro>(query.getResultList(), PageCriteria.getPageRequest(criteria), query.getResultList().size());
+		return new PageImpl<Roteiro>(query.getResultList(), PageCriteria.getPageRequest(criteria), totalElements);
 	}
 
 }


### PR DESCRIPTION
### Qual era o problema?

> Eram buscados apenas o número do pageSize, apresentando totalElements errado.

### Como ele foi resolvido? 

> Buscando o totalElements antes de settar pageSize e maxResults para a query.

### Qual o resultado esperado? 

> TotalElements correto na tela de projetos.
